### PR TITLE
Let anchor take up full space of menu list item

### DIFF
--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -337,6 +337,7 @@ a.indexable {
     a {
       color: $color-index-fg;
       text-decoration: none;
+      display: block;
     }
     a:hover {
       // use different color on index-item hover


### PR DESCRIPTION
Anchor currently doesn't take up the full space of the menu item. The hover is currently on the menu item which makes you think you can click on a link when hovering over the menu item but _not_ hovering over the text.
This PR fixes that and allows the anchor to take up the full size of the list item, never yielding a false positive clickable moment.

See gif below for more info:
![screencast 2018-08-28 15-53-44](https://user-images.githubusercontent.com/4106/44747697-c9807980-aadb-11e8-914b-947bc29661da.gif)
