### PR TITLE
Fix index collapsible for all browsers.

### DIFF
--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -121,9 +121,6 @@ footer {
       a {
         display: inline-flex;
         position: relative;
-        left: 20px;
-        top: -16px;
-        width: 100%;
         height: 100%;
         max-width: 180px;
       }


### PR DESCRIPTION
The relative positioning of indexes that represented collapsible menus appears to not work properly only on Mozilla.  This should fix that.