### PR TITLE
Release runtimes of the version 1.12.0 for OpenWhisk

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -76,6 +76,145 @@ layout: default
                   <div class="content">
                    <div class="flow-columns">
                       <div class="project-structure-repo theme-deeper-sea-green">
+                        <h4>OpenWhisk Runtime Node.js</h4>
+                        <p class="repo-title border-deeper-sea-green">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-0.9.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-sea-green">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-sea-green">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+
+                      <div class="project-structure-repo theme-deeper-sky-blue">
+                        <h4>OpenWhisk Runtime Java</h4>
+                        <p class="repo-title border-deeper-sky-blue">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-sky-blue">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-sky-blue">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+
+                      <div class="project-structure-repo theme-darkgoldenrod">
+                        <h4>OpenWhisk Runtime Docker</h4>
+                        <p class="repo-title border-darkgoldenrod">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-darkgoldenrod">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-darkgoldenrod">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+
+                      <div class="project-structure-repo theme-deeper-aquamarine">
+                        <h4>OpenWhisk Runtime Python</h4>
+                        <p class="repo-title border-deeper-aquamarine">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-aquamarine">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-deeper-aquamarine">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+
+                      <div class="project-structure-repo theme-darksalmon">
+                        <h4>OpenWhisk Runtime PHP</h4>
+                        <p class="repo-title border-darksalmon">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-darksalmon">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-darksalmon">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+
+                      <div class="project-structure-repo theme-darkorange">
+                        <h4>OpenWhisk Runtime Swift</h4>
+                        <p class="repo-title border-darkorange">
+                          <a
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz&action=download">
+                            Source code
+                          </a>
+                        </p>
+                        <p class="repo-title border-darkorange">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz.sha512">
+                            SHA-512 checksum
+                          </a>
+                        </p>
+                        <p class="repo-title border-darkorange">
+                          <a
+                            href="https://www.apache.org/dist/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz.asc">
+                            PGP signature
+                          </a>
+                        </p>
+                      </div>
+                   </div>
+                  </div>
+                </div>
+
+                <h5 class="section-toggle section-toggle-start-open ">1.12.x-incubating (2018-09-25)</h5>
+                <div class="section-start-open">
+                  <div class="content">
+                    <div class="flow-columns">
+                      <div class="project-structure-repo theme-deeper-sea-green">
                         <h4>OpenWhisk</h4>
                         <p>Core service of OpenWhisk.</p>
                         <p class="repo-title border-deeper-sea-green">
@@ -212,8 +351,8 @@ layout: default
                           </a>
                         </p>
                       </div>
-                   </div>
-                </div>
+                    </div>
+                  </div>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
This PR are dedicated to the following runtimes: NodeJs, Java, Docker, PHP, Python and Swift.