### PR TITLE
Fix spacing issues caused by bad whitespace interp. in home page source

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -35,9 +35,7 @@ layout: default
                 <a href="https://github.com/apache/incubator-openwhisk/blob/master/docs/actions.md#openwhisk-actions">Actions</a>),
                 in any supported programming language, that can be dynamically
                 scheduled and run in response to associated events (via
-                <a href="https://github.com/apache/incubator-openwhisk/blob/master/docs/triggers_rules.md#creating-triggers-and-rules">Triggers</a>)
-                from external sources (
-                <a href="https://github.com/apache/incubator-openwhisk/blob/master/docs/feeds.md#implementing-feeds">Feeds</a>)
+                <a href="https://github.com/apache/incubator-openwhisk/blob/master/docs/triggers_rules.md#creating-triggers-and-rules">Triggers</a>) from external sources (<a href="https://github.com/apache/incubator-openwhisk/blob/master/docs/feeds.md#implementing-feeds">Feeds</a>)
                 or from HTTP requests. The project includes a REST API-based
                 Command Line Interface (CLI) along with other tooling to
                 support packaging, catalog services and many popular container


### PR DESCRIPTION
the desctiption of the project had an extra space in it around a parens:

```
( Feed)
```

Which was caused by a bad whitespace interp. by the compiler; had to adjust source so a line break did not occur between the parens and the start of a hyperlink anchor...