### PR TITLE
Add a project-specific Security reporting instruction page.

### DIFF
--- a/_includes/partial/site-footer.html
+++ b/_includes/partial/site-footer.html
@@ -24,7 +24,7 @@
             <a class="" href="http://www.apache.org/">Apache&nbsp;Software&nbsp;Foundation</a>
             <a class="" href="https://apache.org/events/current-event">Events</a>
             <a class="" href="http://www.apache.org/licenses/">License</a>
-            <a class="" href="http://www.apache.org/security/">Security</a>
+            <a class="" href="security.html">Security</a>
             <a class="" href="http://www.apache.org/foundation/thanks.html">Thanks</a>
             <a class="" href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
         </div>

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -34,7 +34,7 @@ layout: default
                 <div class="collapsible-content">
                   <p>It is strongly encouraged that security vulnerabilities be reported to our private mailing list first, rather than disclosing them in a public forum. The private security mailing address is: <a href="mailto:private@openwhisk.apache.org">private@openwhisk.apache.org</a></p>
                   <p>Please note that this mailing list should only be used for reporting undisclosed security vulnerabilities for Apache OpenWhisk code or dependent libraries, runtimes and tooling. We do not accept regular bug reports or other queries at this address.</p>
-                  <p>The OpenWhisk project management committee upon receiving the report witll follow the Apache <a href="https://www.apache.org/security/committers.html#vulnerability-handling">Vulnerability handling</a> process as documented.
+                  <p>The OpenWhisk project management committee upon receiving the report will follow the Apache <a href="https://www.apache.org/security/committers.html#vulnerability-handling">Vulnerability handling</a> process as documented.
                   </p>
                 </div>
             </div>

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,48 @@
+---
+layout: default
+---
+<!--
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+-->
+<div id="whiskIndexedLayout">
+
+    <!-- Community Index -->
+    <div id="whiskIndex">
+        <ul>
+            <li><a href="#report">Security</a></li>
+            <li><a href="#report">Report a security vulnerability</a></li>
+
+        </ul>
+    </div>
+
+    <section id="whiskNodes">
+        <main class="doc">
+            <div class="content">
+                <a class="indexable" id="downloads"></a>
+                <h2>Security</h2>
+                <div class="collapsible-content">
+                    <p>This page contains information on how to report a security vulnerability within the Apache OpenWhisk project.</p>
+                </div>
+            </div>
+        </main>
+
+        <main class="doc">
+            <div class="content">
+                <a class="indexable" id="report"></a>
+                <h3>Report a security vulnerability</h3>
+                <div class="collapsible-content">
+                  <p>It is strongly encouraged that security vulnerabilities be reported to our private mailing list first, rather than disclosing them in a public forum. The private security mailing address is: <a href="mailto:private@openwhisk.apache.org">private@openwhisk.apache.org</a></p>
+                  <p>Please note that this mailing list should only be used for reporting undisclosed security vulnerabilities for Apache OpenWhisk code or dependent libraries, runtimes and tooling. We do not accept regular bug reports or other queries at this address.</p>
+                  <p>The OpenWhisk project management committee upon receiving the report witll follow the Apache <a href="https://www.apache.org/security/committers.html#vulnerability-handling">Vulnerability handling</a> process as documented.
+                  </p>
+                </div>
+            </div>
+        </main>
+        <main class="doc">
+            <div class="content"><p><i><b>Note</b>: The Apache OpenWhisk community works in accordance with documented Apache security processes documented here: <a href="http://www.apache.org/security/">Reporting a vulnerability</a></i></p>
+            </div>
+        </main>
+    </section>
+
+</div>

--- a/security.md
+++ b/security.md
@@ -1,0 +1,11 @@
+---
+layout: security
+title: Apache OpenWhisk Security
+lede: Information on how to report and manage security vulnerabilities
+---
+
+# OpenWhisk Security
+
+This markdown is not used.
+
+To update content, make changes in `_layouts/security.html`.


### PR DESCRIPTION
Reviewing the project maturity model and seeing what other project websites have done, it seemed that we should create a project specific instruction page on how to report project-related security vulnerabilities and not point to the generic Apache security page.