### PR TITLE
Remove &action=download from download links

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -108,7 +108,7 @@ layout: default
                         <p>Core OpenWhisk Platform Components.</p>
                         <p class="repo-title border-deeper-sea-green">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-0.9.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -131,7 +131,7 @@ layout: default
                         <p>A performant API Gateway based on Openresty and NGINX.</p>
                         <p class="repo-title border-darkorange">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-apigateway-0.9.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-apigateway-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -160,7 +160,7 @@ layout: default
                         <h5>OpenWhisk Runtime Node.js</h5>
                         <p class="repo-title border-deeper-sea-green">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -182,7 +182,7 @@ layout: default
                         <h5>OpenWhisk Runtime Java</h5>
                         <p class="repo-title border-deeper-sky-blue">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -204,7 +204,7 @@ layout: default
                         <h5>OpenWhisk Runtime Docker</h5>
                         <p class="repo-title border-darkgoldenrod">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -226,7 +226,7 @@ layout: default
                         <h5>OpenWhisk Runtime Python</h5>
                         <p class="repo-title border-deeper-aquamarine">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -248,7 +248,7 @@ layout: default
                         <h5>OpenWhisk Runtime PHP</h5>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -270,7 +270,7 @@ layout: default
                         <h5>OpenWhisk Runtime Swift</h5>
                         <p class="repo-title border-darkorange">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -300,7 +300,7 @@ layout: default
                         <p>OpenWhisk command-line interface.</p>
                         <p class="repo-title border-deeper-sky-blue">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-cli-0.9.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-cli-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -323,7 +323,7 @@ layout: default
                         <p>OpenWhisk client library in Go.</p>
                         <p class="repo-title border-darkgoldenrod">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-client-go-0.9.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-client-go-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -346,7 +346,7 @@ layout: default
                         <p>OpenWhisk utility to configure OpenWhisk entities with a Manifest file written in YAML, and deploy them in a single command.</p>
                         <p class="repo-title border-deeper-aquamarine">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.8-incubating/openwhisk-wskdeploy-0.9.8-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.8-incubating/openwhisk-wskdeploy-0.9.8-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -376,7 +376,7 @@ layout: default
                         <p>Package catalogs of OpenWhisk, which provides an easy way to enhance your application with useful capabilities, and to access external services in the ecosystem.</p>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-catalog-0.9.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-catalog-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -399,7 +399,7 @@ layout: default
                         <p>Composer is a new programming model for composing cloud functions built on OpenWhisk</p>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-composer-0.10.0-incubating-sources.tar.gz&action=download">
+                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-composer-0.10.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>


### PR DESCRIPTION
Per comment from Craig Russell on the incubator list [1], download
links should not include &action=download because users are supposed
to be select their own mirror for the download.

[1] https://lists.apache.org/thread.html/63f6033b9f5eca93e032f33e20784594f2cb6b42ebdf98c4363db9de@%3Cgeneral.incubator.apache.org%3E