### PR TITLE
Can't read black text on dark blue background.

### DIFF
--- a/_scss/_highlite-syntax-colors.scss
+++ b/_scss/_highlite-syntax-colors.scss
@@ -40,7 +40,7 @@
 .highlight .nn { color: #0e84b5; font-weight: 400 } /* Name.Namespace */
 .highlight .nt { color: #007700 } /* Name.Tag */
 .highlight .nv { color: #7899ba } /* Name.Variable */
-.highlight .ow { color: #000000; font-weight: 400 } /* Operator.Word */
+.highlight .ow { font-weight: 400 } /* Operator.Word */
 .highlight .w { color: #bbbbbb } /* Text.Whitespace */
 .highlight .mb { color: #6600EE; font-weight: 400 } /* Literal.Number.Bin */
 .highlight .mf { color: #6600EE; font-weight: 400 } /* Literal.Number.Float */


### PR DESCRIPTION
Python keyword 'in' was rendered black. You can't read that on a  dark-blue-ish background.