### PR TITLE
Long terminal lines should not be truncated.

### DIFF
--- a/_scss/_terminal.scss
+++ b/_scss/_terminal.scss
@@ -8,6 +8,7 @@
     padding: $terminal-padding;
     width: $terminal-width;
     margin-bottom: $terminal-margin-bottom;
+    overflow: auto;
 
     // Note: options: white-space: normal|nowrap|pre|pre-line|pre-wrap
     // Note: non-std. options:  white-space: -moz-pre-wrap | -o-pre-wrap;


### PR DESCRIPTION
So offer a (horizontal) scroll bar.

Alternative to #369