### PR TITLE
Fix download links

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -112,7 +112,7 @@ layout: default
                         <p>Core OpenWhisk Platform Components.</p>
                         <p class="repo-title border-deeper-sea-green">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-0.9.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -135,7 +135,7 @@ layout: default
                         <p>A performant API Gateway based on Openresty and NGINX.</p>
                         <p class="repo-title border-darkorange">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-apigateway-0.9.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-apigateway-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -164,7 +164,7 @@ layout: default
                         <h5>OpenWhisk Runtime Node.js</h5>
                         <p class="repo-title border-deeper-sea-green">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-nodejs-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -186,7 +186,7 @@ layout: default
                         <h5>OpenWhisk Runtime Java</h5>
                         <p class="repo-title border-deeper-sky-blue">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-java-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -208,7 +208,7 @@ layout: default
                         <h5>OpenWhisk Runtime Docker</h5>
                         <p class="repo-title border-darkgoldenrod">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-docker-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -230,7 +230,7 @@ layout: default
                         <h5>OpenWhisk Runtime Python</h5>
                         <p class="repo-title border-deeper-aquamarine">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-python-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -252,7 +252,7 @@ layout: default
                         <h5>OpenWhisk Runtime PHP</h5>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-php-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -274,7 +274,7 @@ layout: default
                         <h5>OpenWhisk Runtime Swift</h5>
                         <p class="repo-title border-darkorange">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-1.12.0-incubating/openwhisk-runtime-swift-1.12.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -304,7 +304,7 @@ layout: default
                         <p>OpenWhisk command-line interface.</p>
                         <p class="repo-title border-deeper-sky-blue">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-cli-0.10.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-cli-0.10.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -327,7 +327,7 @@ layout: default
                         <p>OpenWhisk client library in Go.</p>
                         <p class="repo-title border-darkgoldenrod">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-client-go-0.10.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-client-go-0.10.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -350,7 +350,7 @@ layout: default
                         <p>OpenWhisk utility to configure OpenWhisk entities with a Manifest file written in YAML, and deploy them in a single command.</p>
                         <p class="repo-title border-deeper-aquamarine">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-wskdeploy-0.10.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-wskdeploy-0.10.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -380,7 +380,7 @@ layout: default
                         <p>Package catalogs of OpenWhisk, which provides an easy way to enhance your application with useful capabilities, and to access external services in the ecosystem.</p>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-catalog-0.9.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.9.0-incubating/openwhisk-catalog-0.9.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>
@@ -403,7 +403,7 @@ layout: default
                         <p>Composer is a new programming model for composing cloud functions built on OpenWhisk</p>
                         <p class="repo-title border-darksalmon">
                           <a
-                            href="https://www.apache.org/dyn/closer.lua?filename=incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-composer-0.10.0-incubating-sources.tar.gz">
+                            href="https://www.apache.org/dyn/closer.cgi/incubator/openwhisk/apache-openwhisk-0.10.0-incubating/openwhisk-composer-0.10.0-incubating-sources.tar.gz">
                             Source code
                           </a>
                         </p>


### PR DESCRIPTION
Fix download links broken in 49d939.  The URL pattern I
was following from clutch was not correct.  This version
using closer.cgi actually works as intended...