### PR TITLE
Add query parm on master CSS import link to force client refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ bundle exec jekyll build
 
 This will build static files to a directory called `_site/` in the project root. This can be used for manual deployment to a static server or with build tools like Jenkins.
 
+## Updating CSS files
+
+Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ``<link>``` within [default.html](_layouts/default.html) which will force clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
+
+```
+<link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.12">
+```
+
+for example, update "?v1.12" to "?v1.13".
+
+```
+<link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.13">
+```
+
 ## Troubleshooting
 
 If you get an error 'bundle: command not found' attempting to build the site, you may need to manually install the 'bundler' package:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This will build static files to a directory called `_site/` in the project root.
 
 ## Updating CSS files
 
-Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ``<link>``` within [default.html](_layouts/default.html) which will cause (force) some clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
+Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ```<link>``` within [default.html](_layouts/default.html) which will cause (force) some clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
 
 ```
 <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.12">

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ This will build static files to a directory called `_site/` in the project root.
 
 Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ```<link>``` within [default.html](_layouts/default.html) which will cause (force) some clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
 
-```
+```html
 <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.12">
 ```
 
 for example, update "?v1.12" to "?v1.13".
 
-```
+```html
 <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.13">
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This will build static files to a directory called `_site/` in the project root.
 
 ## Updating CSS files
 
-Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ``<link>``` within [default.html](_layouts/default.html) which will force clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
+Some browsers will continue to use cached copies of ".css" files even though the styles/content in the files has changed significantly.  If you make any changes that affect layout, you SHOULD increment the (artificial) version number on the query parameter on the ``<link>``` within [default.html](_layouts/default.html) which will cause (force) some clients to pull down a new ```main.css``` file (and all the cascading CSS imports as well):
 
 ```
 <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.12">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
         {% include head/favicon.html %}
         <title>{{ page_title }}</title>
         <link href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i" rel="stylesheet">
-        <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css">
+        <link rel="stylesheet" href="{{ site.github.url }}/css/main-v1.css?v=1.13">
         <!-- Load Index, Menu & collapsible support -->
         <script type="text/javascript">
             {% include index/index.js %}


### PR DESCRIPTION
Some clients need a little indicator () to cause them to download/use a new .CSS file and not pull from their local cache as they are not smart enough to detect changes in dependent files themselves.