### PR TITLE
Promote dev list. Clarify when Slack should be used.

### DIFF
--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -45,46 +45,21 @@ layout: default
               <a class="indexable" id="community"></a>
               <h2>Community</h2>
               <div>
-                  <p>The Apache OpenWhisk community attempts to engage its users and developers in as many channels as we are able. Please find and subscribe to the ones that are right for you!</p>
+                  <p>The Apache OpenWhisk community attempts to engage its users and developers in as many channels as we are able. Please find and subscribe to the ones that are right for you. If you wish to engage our community's Contributors and Committers around project architecture, design and source code, please subscribe to and participate in our developer mailing list as described below.</p>
               </div>
-          </div>
-      </main>
-      <main class="doc">
-          <div class="content">
-              <a class="indexable" id="social"></a>
-              <h3>Media</h3>
-              <p>The Apache OpenWhisk project is active on several content sharing and social media channels which aim to make it easier for users to get started, ask questions, stay informed and to interact with our community.</p>
-              <p>Icons that link to each of the following channels are located in the header of our website and include:</p>
-              <ul>
-                  <a class="indexable" id="github"></a>
-                  <li><a href="https://github.com/apache?q=openwhisk" title="Apache OpenWhisk project repositories on GitHub">GitHub</a>: Browse the source code, documentation and tests for all the repositories that make up our project component, deployment and tooling ecosystem.</li>
-                  <a class="indexable" id="slack"></a>
-                  <li><a href="http://openwhisk-team.slack.com/" title="Apache OpenWhisk on Slack">Slack</a>: Engage the OpenWhisk developer community directly in conversations across several topics.</li>
-                  <ul><li><a href="slack.html">Request an invitation</a></li></ul>
-                  <li><a href="https://medium.com/openwhisk" title="Apache OpenWhisk on Medium">Medium</a>: Read the latest blog posts on the OpenWhisk project including how-tos, use cases, architecture topics and more.</li>
-                  <a class="indexable" id="twitter"></a>
-                  <li><a href="https://twitter.com/search?q=openwhisk" title="Apache OpenWhisk on Twitter">Twitter</a>: Follow for the latest news from the OpenWhisk ecosystem.</li>
-                  <a class="indexable" id="youtube"></a>
-                  <li><a href="https://www.youtube.com/channel/UCbzgShnQk8F43NKsvEYA1SA" title="Apache OpenWhisk on YouTube">YouTube</a>: See demos of OpenWhisk in action as well as recordings of community meetings and events.</li>
-                  <a class="indexable" id="stackoverflow"></a>
-                  <li><a href="https://stackoverflow.com/questions/tagged/openwhisk">Stack Overflow</a>: Ask questions and find answers about how to use OpenWhisk.</li>
-                  <a class="indexable" id="slideshare"></a>
-                  <li><a href="https://www.slideshare.net/OpenWhisk">SlideShare</a>: Look over slides from many of the presentations from past events.</li>
-              </ul>
-              <p>If you wish to engage our community's Contributors and Committers around project architecture, design and source code, please subscribe to and participate in our developer mailing list as described below.</p>
           </div>
       </main>
       <main class="doc">
           <div class="content">
               <a class="indexable" id="mailing-lists"></a>
               <h3>Mailing Lists</h3>
-              <p>The developer or "dev" mailing list is where we discuss the design and
+              <p>The developer or "dev" mailing list is where we discuss <b><i>all</i></b> the design and
                 development of Apache OpenWhisk project code.
-                It is <b><i>not</i></b> a place for technical support;
+                It is <b><i>not</i></b> however a place for technical support;
                 if you're looking for help on the project, please try our
                 <a style="font-weight:400;" href="/documentation.html">Documentation</a>
                 page and engage with us on one of the Social Media channels
-                listed above.
+                listed below.
               </p>
               <question>How do I join the Apache OpenWhisk project
                 developer mailing list?</question>
@@ -102,6 +77,30 @@ layout: default
                 subscribe/unsubscribe messages. Empty emails are ignored.</p>
               <p>To see existing messages, use:
                 <a href="https://lists.apache.org/list.html?dev@openwhisk.apache.org">https://lists.apache.org/list.html?dev@openwhisk.apache.org</a>.</p>
+          </div>
+      </main>
+      <main class="doc">
+          <div class="content">
+              <a class="indexable" id="social"></a>
+              <h3>Media</h3>
+              <p>The Apache OpenWhisk project is active on several content sharing and social media channels which aim to make it easier for users to get started, ask questions, stay informed and to interact with our community. If you wish to engage our community's Contributors and Committers around project architecture, design and source code, please subscribe to and participate in our developer mailing list as described above.</p>
+
+              <p>Icons that link to each of the following channels are located in the header of our website and include:</p>
+              <ul>
+                  <a class="indexable" id="github"></a>
+                  <li><a href="https://github.com/apache?q=openwhisk" title="Apache OpenWhisk project repositories on GitHub">GitHub</a>: Browse the source code, documentation and tests for all the repositories that make up our project component, deployment and tooling ecosystem.</li>
+                  <a class="indexable" id="slack"></a>
+                  <li><a href="slack.html" title="Apache OpenWhisk on Slack">Slack</a>: Engage the OpenWhisk developer community directly in conversations across several topics. Slack is intended for quickly getting help, not deep technical discussions. The place for the latter and all important topics is the project "dev" list.</li>
+                  <li><a href="https://medium.com/openwhisk" title="Apache OpenWhisk on Medium">Medium</a>: Read the latest blog posts on the OpenWhisk project including how-tos, use cases, architecture topics and more.</li>
+                  <a class="indexable" id="twitter"></a>
+                  <li><a href="https://twitter.com/search?q=openwhisk" title="Apache OpenWhisk on Twitter">Twitter</a>: Follow for the latest news from the OpenWhisk ecosystem.</li>
+                  <a class="indexable" id="youtube"></a>
+                  <li><a href="https://www.youtube.com/channel/UCbzgShnQk8F43NKsvEYA1SA" title="Apache OpenWhisk on YouTube">YouTube</a>: See demos of OpenWhisk in action as well as recordings of community meetings and events.</li>
+                  <a class="indexable" id="stackoverflow"></a>
+                  <li><a href="https://stackoverflow.com/questions/tagged/openwhisk">Stack Overflow</a>: Ask questions and find answers about how to use OpenWhisk. Use the tag "openwhisk".</li>
+                  <a class="indexable" id="slideshare"></a>
+                  <li><a href="https://www.slideshare.net/OpenWhisk">SlideShare</a>: Look over slides from many of the presentations from past events.</li>
+              </ul>
           </div>
       </main>
       <main class="doc">


### PR DESCRIPTION
This PR makes small but important changes to the communication page to clarify that _all_ important conversations happen on the dev list. It also add a short blurb about the usage of Slack.

cc @bdelacretaz 
<img width="1183" alt="Screen Shot 2019-06-07 at 12 07 35 PM" src="https://user-images.githubusercontent.com/4959922/59118308-ca252680-891d-11e9-9fb0-c74c5fcb31b4.png">
<img width="1176" alt="Screen Shot 2019-06-07 at 12 07 45 PM" src="https://user-images.githubusercontent.com/4959922/59118314-cbeeea00-891d-11e9-9d7a-0e1cd3db085a.png">

