### PR TITLE
Add trademark guidelines page for OpenWhisk name and logo

### DIFF
--- a/_includes/partial/site-footer.html
+++ b/_includes/partial/site-footer.html
@@ -21,28 +21,29 @@
   <main class="footer-row">
     <div>
         <div class="footer-row-text-links">
-            <a class="" href="http://www.apache.org/">Apache&nbsp;Software&nbsp;Foundation</a>
+            <a class="" href="https://www.apache.org/">Apache&nbsp;Software&nbsp;Foundation</a>
             <a class="" href="https://apache.org/events/current-event">Events</a>
-            <a class="" href="http://www.apache.org/licenses/">License</a>
+            <a class="" href="https://www.apache.org/licenses/">License</a>
             <a class="" href="security.html">Security</a>
-            <a class="" href="http://www.apache.org/foundation/thanks.html">Thanks</a>
-            <a class="" href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
+            <a class="" href="https://www.apache.org/foundation/thanks.html">Thanks</a>
+            <a class="" href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
         </div>
     </div>
   </main>
   <main class="footer-row">
     <div>
       Apache OpenWhisk, OpenWhisk, Apache, the Apache feather logo, and
-      the Apache OpenWhisk project logo are either registered trademarks
-      or trademarks of The Apache Software Foundation
-      in the United States and other countries.
-      See guidance on use of Apache OpenWhisk trademarks.
+      the Apache OpenWhisk project logo are either registered
+      registered <a href="trademarks.html">trademarks</a> or
+      trademarks of The Apache Software Foundation in the United States and other countries.
+      See <a href="trademarks.html">guidance</a> on use of Apache OpenWhisk trademarks.
       All other marks mentioned may be trademarks or registered trademarks
       of their respective owners.
     </div>
   </main>
   <main class="footer-row">
       <div>
+        <em>
           Apache OpenWhisk is an effort undergoing incubation at The Apache
           Software Foundation (ASF), sponsored by the Incubator.
           Incubation is required of all newly accepted projects until a further
@@ -52,6 +53,7 @@
           reflection of the completeness or stability of the code,
           it does indicate that the project has yet to be fully endorsed
           by the ASF.
+        </em>
       </div>
   </main>
   <main class="footer-row">

--- a/_layouts/trademarks.html
+++ b/_layouts/trademarks.html
@@ -10,7 +10,7 @@ layout: default
     <!-- Community Index -->
     <div id="whiskIndex">
         <ul>
-            <li><a href="#report">Trademark Guidelines</a></li>
+            <li>Trademark Guidelines</li>
 
         </ul>
     </div>

--- a/_layouts/trademarks.html
+++ b/_layouts/trademarks.html
@@ -1,0 +1,89 @@
+---
+layout: default
+---
+<!--
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+-->
+<div id="whiskIndexedLayout">
+
+    <!-- Community Index -->
+    <div id="whiskIndex">
+        <ul>
+            <li><a href="#report">Trademark Guidelines</a></li>
+
+        </ul>
+    </div>
+
+
+    <section id="whiskNodes">
+        <main class="doc">
+            <div class="content">
+                <a class="indexable" id="trademarks"></a>
+                <h2>Apache OpenWhisk Trademark Guidelines</h2>
+            </div>
+        </main>
+
+        <main class="doc">
+            <div class="content">
+
+                <p>Apache OpenWhisk, OpenWhisk and the OpenWhisk logo are
+                <a href="https://www.apache.org/foundation/marks/">trademarks</a>
+                of the <a href="https://www.apache.org/">Apache Software Foundation (ASF)</a>.
+                The ASF is a 501(c)(3) nonprofit organization, and as such, needs to take
+                special care about how its trademarks are used by organizations.
+                In particular, ASF needs to ensure that its software products are clearly
+                distinguished from third-party products.</p>
+
+                <p>If you would like to provide software, services, events, or other products
+                based on Apache OpenWhisk, please refer to the
+                <a href="https://www.apache.org/foundation/marks/">ASF trademark policy</a>
+                and <a href="https://www.apache.org/foundation/marks/faq/">FAQ</a>.
+                This page summarizes the key points of the policy, but please note that
+                the official policy always takes precedence.</p>
+
+                <ul>
+                  <li><strong>Software products,</strong> whether commercial or open source, are not allowed to use “OpenWhisk” in their name, except in the form “powered by Apache OpenWhisk" or “for Apache OpenWhisk” when following
+                <a href="https://www.apache.org/foundation/marks/faq/#products">these specific
+                guidelines</a>.
+                    <ul>
+                      <li>Names derived from “OpenWhisk” are also not allowed.</li>
+                      <li>Company names may not include “OpenWhisk”.</li>
+                      <li>Package identifiers (e.g., Maven coordinates) may include
+                       “openwhisk”, but the full name used for the software package should
+                       follow the naming policy above.</li>
+                    </ul>
+                  </li>
+                  <li>
+                    <p><strong>Written materials</strong> must refer to the project as “Apache OpenWhisk” in the first and most prominent mentions. Materials from software vendors or software-related service providers must follow
+                <a href="https://www.apache.org/foundation/marks/guide#howoften">stricter
+                guidelines</a>, including using the full project name “Apache OpenWhisk" in more
+                locations, and proper
+                <a href="https://www.apache.org/foundation/marks/faq/#attribution">trademark
+                attribution</a> on every page.</p>
+                  </li>
+                  <li>
+                    <p><strong>Logos</strong> derived from the OpenWhisk logo are not allowed.</p>
+                  </li>
+                  <li>
+                    <p><strong>Domain names</strong> containing “openwhisk” are not permitted without written permission from the Apache OpenWhisk PMC. To request permission, email
+                <a href="mailto:private@openwhisk.apache.org">private@openwhisk.apache.org</a> and CC
+                <a href="mailto:trademarks@apache.org">trademarks@apache.org</a>.
+                (<a href="https://www.apache.org/foundation/marks/domains.html">Details</a>)</p>
+                  </li>
+                  <li><strong>Events, books, and merchandise</strong> have their own guidelines.
+                Please refer to the
+                <a href="https://www.apache.org/foundation/marks/">ASF trademark policy</a>
+                and <a href="https://www.apache.org/foundation/marks/faq/">FAQ</a> for details.</li>
+                </ul>
+
+                <p>We appreciate the community’s help in respecting these guidelines.
+                If you have any questions about the Apache trademark policy, please email
+                <a href="mailto:trademarks@apache.org">trademarks@apache.org</a>.</p>
+
+            </div>
+        </main>
+    </section>
+-->
+
+</div>

--- a/_layouts/trademarks.html
+++ b/_layouts/trademarks.html
@@ -84,6 +84,5 @@ layout: default
             </div>
         </main>
     </section>
--->
 
 </div>

--- a/trademarks.md
+++ b/trademarks.md
@@ -1,0 +1,11 @@
+---
+layout: trademarks
+title: Apache OpenWhisk Trademark Guidelines
+lede: Apache OpenWhisk, OpenWhisk and the OpenWhisk logo are trademarks of the Apache Software Foundation (ASF) and any (intended) usage must follow these guidelines.
+---
+
+# Apache OpenWhisk Trademark Guidelines
+
+This markdown is not used.
+
+To update content, make changes in `_layouts/trademarks.html`.


### PR DESCRIPTION
Used Apache Spark as the model example as suggested on the dev. list by Bertrand.