### PR TITLE
Add clarification around use of openwhisk name for repos

### DIFF
--- a/_layouts/trademarks.html
+++ b/_layouts/trademarks.html
@@ -49,9 +49,10 @@ layout: default
                     <ul>
                       <li>Names derived from “OpenWhisk” are also not allowed.</li>
                       <li>Company names may not include “OpenWhisk”.</li>
-                      <li>Package identifiers (e.g., Maven coordinates) may include
+                      <li>Package identifiers (i.e., package names) may include
                        “openwhisk”, but the full name used for the software package should
                        follow the naming policy above.</li>
+                      <li>Source code repository names (e.g., GitHub) may contain the word "openwhisk" as long as it is used to describe unofficial derivative works (such as applications, demos, 3rd party packages, etc.) of the Apache OpenWhisk project and do not claim to represent the OpenWhisk project itself.  Such repositories should prominently mention the Apache OpenWhisk project in accordance with Apache policy where possible.</li>
                     </ul>
                   </li>
                   <li>


### PR DESCRIPTION
on the trademarks page.