### PR TITLE
Add "jekyll" label to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,6 +30,7 @@ github:
     - docker
     - kubernetes
     - functions
+    - jekyll
   protected_branches:
     master:
       required_status_checks:


### PR DESCRIPTION
Adding the **_jekyll_** label so that its easier to find ASF projects using [Jekyll](https://jekyllrb.com/)

(I've created an [Infra PR](https://github.com/apache/infrastructure-website/pull/255) to add [this GitHub Query](https://github.com/search?q=topic%3Ajekyll+org%3Aapache&type=Repositories) to the [Infra Project Website page](https://infra.apache.org/project-site.html#sitemanagement))